### PR TITLE
Update agency filter options to simplify specialisation selection

### DIFF
--- a/apps/web/src/components/agencies/AgencyFilterDrawer.tsx
+++ b/apps/web/src/components/agencies/AgencyFilterDrawer.tsx
@@ -37,10 +37,9 @@ export function AgencyFilterDrawer({
   };
 
   const classificationOptions = [
-    { value: 'all', label: 'All Specializations', description: 'Show all agency types' },
-    { value: 'Commercial', label: 'Commercial Property', description: 'Offices, retail, industrial spaces' },
-    { value: 'Residential', label: 'Residential Property', description: 'Houses, apartments, residential developments' },
-    { value: 'Both', label: 'Commercial & Residential', description: 'Full-service property agencies' }
+    { value: 'all', label: 'All Specialisations', description: 'Show all agency types' },
+    { value: 'Commercial', label: 'Commercial Property', description: 'Agencies specialising in commercial properties' },
+    { value: 'Residential', label: 'Residential Property', description: 'Agencies specialising in residential properties' }
   ];
 
   if (!isOpen) return null;

--- a/apps/web/src/components/agencies/AgencySearchHeader.tsx
+++ b/apps/web/src/components/agencies/AgencySearchHeader.tsx
@@ -242,7 +242,7 @@ export function AgencySearchHeader({
                     {classification && classification !== 'all' && (
                       <div className="inline-flex items-center gap-1 px-3 py-1 bg-violet-100 text-violet-800 rounded-full text-sm font-medium">
                         <Filter className="h-3 w-3" />
-                        {classification === 'Both' ? 'Commercial & Residential' : `${classification} Property`}
+                        {`${classification} Property`}
                         <button
                           onClick={handleRemoveClassificationFilter}
                           className="ml-1 p-0.5 hover:bg-violet-200 rounded-full transition-colors"


### PR DESCRIPTION
- Remove 'Commercial & Residential' filter option
- Update filter labels to use British spelling 'Specialisations'
- Simplify filter pill display logic
- Commercial filter now returns agencies with 'Commercial' or 'Both' specialisations
- Residential filter now returns agencies with 'Residential' or 'Both' specialisations

🤖 Generated with [Claude Code](https://claude.ai/code)