### PR TITLE
Replace 'View Pricing' button with 'Watch Demo' button on homepage

### DIFF
--- a/apps/web/src/components/homepage2/Hero.tsx
+++ b/apps/web/src/components/homepage2/Hero.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import { TrialSignupModal } from '@/components/TrialSignupModal';
 import { AuthChoiceModal } from '@/components/auth/auth-choice-modal';
 import { AlreadySubscribedModal } from '@/components/AlreadySubscribedModal';
+import { VideoLightbox } from '@/components/VideoLightbox';
 import { useAuth } from '@/contexts/auth-context';
 import Link from 'next/link';
 import { Loader2, PenTool, Mail } from 'lucide-react';
@@ -13,6 +14,10 @@ export function Hero() {
   const { user, profile } = useAuth();
   const [isLoadingCheckout, setIsLoadingCheckout] = useState(false);
   const [showAlreadySubscribed, setShowAlreadySubscribed] = useState(false);
+  const [showVideoLightbox, setShowVideoLightbox] = useState(false);
+
+  // YouTube video ID for demo
+  const DEMO_VIDEO_ID = 'KBOKzYEdPm0';
 
   // Check if user has active subscription directly from profile
   const hasSubscription = profile?.subscription_status === 'active' || profile?.subscription_status === 'trialing';
@@ -118,12 +123,12 @@ export function Hero() {
                       <Link href="/pricing">Start Free Trial</Link>
                     </Button>
                     <Button
-                      asChild
+                      onClick={() => setShowVideoLightbox(true)}
                       size="lg"
                       variant="outline"
                       className="border-3 border-violet-300 hover:border-violet-400 hover:bg-violet-50 px-8 py-5 text-base md:text-lg font-black rounded-2xl hover:shadow-xl transition-all duration-300"
                     >
-                      <Link href="/pricing">View Pricing</Link>
+                      Watch Demo
                     </Button>
                   </>
                 )
@@ -135,12 +140,12 @@ export function Hero() {
                     </Button>
                   </TrialSignupModal>
                   <Button
-                    asChild
+                    onClick={() => setShowVideoLightbox(true)}
                     size="lg"
                     variant="outline"
                     className="border-3 border-violet-300 hover:border-violet-400 hover:bg-violet-50 px-8 py-5 text-base md:text-lg font-black rounded-2xl hover:shadow-xl transition-all duration-300"
                   >
-                    <Link href="/pricing">View Pricing</Link>
+                    Watch Demo
                   </Button>
                 </>
               )}
@@ -322,6 +327,14 @@ export function Hero() {
           subscriptionStatus="active"
         />
       )}
+
+      {/* Video Demo Modal */}
+      <VideoLightbox
+        isOpen={showVideoLightbox}
+        onClose={() => setShowVideoLightbox(false)}
+        videoId={DEMO_VIDEO_ID}
+        title="Product Demo"
+      />
     </section>
   );
 }


### PR DESCRIPTION
Replace the secondary CTA button in the Hero section with a 'Watch Demo' button that opens a YouTube video in a modal overlay, improving engagement and reducing friction for users wanting to learn about the product.

Changes:
- Add VideoLightbox import and state management to Hero component
- Replace both instances of 'View Pricing' button with 'Watch Demo' button
- Add VideoLightbox modal component with YouTube video (ID: KBOKzYEdPm0)
- Change button from navigation link to onClick handler for modal

Behavior:
- Click 'Watch Demo' opens full-screen modal with YouTube video
- Video auto-plays in modal
- Modal can be closed via X button, clicking outside, or pressing Escape
- Users stay on homepage (no navigation away)

Uses existing VideoLightbox component already tested in SiteSketcher landing page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)