### PR TITLE
Remove Marks & Spencer from trusted companies carousel

### DIFF
--- a/apps/web/src/config/trusted-companies.ts
+++ b/apps/web/src/config/trusted-companies.ts
@@ -11,7 +11,6 @@ export const TRUSTED_COMPANY_DOMAINS = [
   'vedragroup.co.uk',
   'colliers.com',
   'morganwilliams.co.uk',
-  'marksandspencer.com',
   'knoops.com',
   'fastnedcharging.com',
   'travelodge.co.uk',


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)